### PR TITLE
Fix broken tests in dvde/add-aci-support

### DIFF
--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Callable, Sequence
 
-import yaml
 from airflow.utils.context import Context
 from cosmos.config import ProfileConfig
 
@@ -64,12 +63,11 @@ class DbtAzureContainerInstanceBaseOperator(AzureContainerInstancesOperator, Abs
             **kwargs,
         )
 
-    def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> int:
+    def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")
-        result = int(super().execute(context))
+        result = super().execute(context)
         logger.info(result)
-        return result
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt
@@ -79,9 +77,6 @@ class DbtAzureContainerInstanceBaseOperator(AzureContainerInstancesOperator, Abs
         dbt_cmd, env_vars = self.build_cmd(context=context, cmd_flags=cmd_flags)
         self.environment_variables: dict[str, Any] = {**env_vars, **self.environment_variables}
         self.command: list[str] = dbt_cmd
-
-    def execute(self, context: Context) -> int:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceBaseOperator):

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -12,7 +12,7 @@ import warnings
 import airflow
 import jinja2
 from airflow import DAG
-from airflow.compat.functools import cached_property
+from functools import cached_property
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.taskinstance import TaskInstance

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 
-from airflow.compat.functools import cached_property
+from functools import cached_property
 from airflow.utils.python_virtualenv import prepare_virtualenv
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 python = ["3.8", "3.9", "3.10", "3.11"]
 airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
 
+[tool.hatch.envs.tests.overrides]
+matrix.airflow.dependencies = [
+    { value = "typing_extensions<4.6", if = ["2.6"] }
+]
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ dependencies = [
     "types-requests",
     "types-python-dateutil",
     "Werkzeug<3.0.0",
+    "typing-extensions<4.6.0",  # to support python 3.8 and 3.9
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,6 @@ dependencies = [
     "types-requests",
     "types-python-dateutil",
     "Werkzeug<3.0.0",
-    "typing-extensions<4.6.0",  # to support python 3.8 and 3.9
     "apache-airflow=={matrix:airflow}.0",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,15 +160,8 @@ dependencies = [
     "types-python-dateutil",
     "Werkzeug<3.0.0",
 ]
-# Airflow install with constraint file, Airflow versions < 2.7 require a workaround for PyYAML
-pre-install-commands = ["""
-    if [[ "2.3 2.4 2.5 2.6" =~ "{matrix:airflow}" ]]; then
-        echo "Cython < 3" >> /tmp/constraint.txt
-        pip wheel "PyYAML==6.0.0" -c /tmp/constraint.txt
-    fi
-    pip install 'apache-airflow=={matrix:airflow}' --constraint 'https://raw.githubusercontent.com/apache/airflow/constraints-{matrix:airflow}.0/constraints-{matrix:python}.txt'
-    """
-]
+pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
+
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]
 airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ dependencies = [
     "types-python-dateutil",
     "Werkzeug<3.0.0",
     "typing-extensions<4.6.0",  # to support python 3.8 and 3.9
+    "apache-airflow=={matrix:airflow}.0",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+AIRFLOW_VERSION="$1"
+PYTHON_VERSION="$2"
+
+CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-$AIRFLOW_VERSION.0/constraints-$PYTHON_VERSION.txt"
+curl -sSL $CONSTRAINT_URL -o /tmp/constraint.txt
+# Workaround to remove PyYAML constraint that will work on both Linux and MacOS
+sed '/PyYAML==/d' /tmp/constraint.txt > /tmp/constraint.txt.tmp
+mv /tmp/constraint.txt.tmp /tmp/constraint.txt
+# Install Airflow with constraints
+pip install apache-airflow==$AIRFLOW_VERSION --constraint /tmp/constraint.txt
+rm /tmp/constraint.txt

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -10,4 +10,5 @@ sed '/PyYAML==/d' /tmp/constraint.txt > /tmp/constraint.txt.tmp
 mv /tmp/constraint.txt.tmp /tmp/constraint.txt
 # Install Airflow with constraints
 pip install apache-airflow==$AIRFLOW_VERSION --constraint /tmp/constraint.txt
+pip install pydantic --constraint /tmp/constraint.txt
 rm /tmp/constraint.txt


### PR DESCRIPTION
There were some fixes needed for type checking and deps in the test environment:
 
- The update in https://github.com/astronomer/astronomer-cosmos/pull/805 added an `execute` method to the base operator so the execute method for the `DbtAzureContainerInstanceBaseOperator` can be removed
-  One of the dependencies of the added `apache-airflow-providers-microsoft-azure` provider in the test environment was installing `typing_extensions>=4.6.0` which was causing issues with the Airflow 2.6 with pydantic dataclasses. 
- The pre-install command for installing Airflow with the constraint was not actually working as expected in some of the testing environments causing issues installing `apache-airflow-providers-microsoft-azure`. The fix here was to move it to a bash shell script and update PyYAML there.

All tests ran successfully [here](https://github.com/astronomer/astronomer-cosmos/pull/831/checks) 